### PR TITLE
Fix small kubernetes.json file permission issues, add GHA workflow with lint and install checks

### DIFF
--- a/.github/workflows/lint_tests.yml
+++ b/.github/workflows/lint_tests.yml
@@ -43,14 +43,6 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@94729529f85113b88f4f819c17ce61382e6d8478 # v1.2.0
 
-      - name: Write Testing Api Key Secrets to values file
-        env:
-          API_KEY_US: "tbd" # reference secret
-          API_KEY_EU: "tbd"
-        run: |
-          mkdir -p ci/
-          echo -e 'scalyr:\n  apiKey: "${API_KEY_US}"' > ci/test-values.yaml
-
       # TODO: Configure testing write API key as Github repo secret
       # TODO: Ideally we would also use read api key to confirm agent.log is correctly ingested
       # TODO: Run install twice (against US and EU)

--- a/.github/workflows/lint_tests.yml
+++ b/.github/workflows/lint_tests.yml
@@ -1,0 +1,75 @@
+name: "Lint and Tests"
+
+on:
+  push:
+    branches:
+      - master
+      - permissions_change_gha_workflow
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: '0 4 * * *'
+
+jobs:
+  lint_test:
+    name: Lint and Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@18bc76811624f360dbd7f18c2d4ecb32c7b87bab # v1.1
+        with:
+          version: v3.7.0
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@5f16c27cf7a4fa9c776ff73734df3909b2b65127 # v2.1.0
+        with:
+          version: v3.4.0
+
+      - name: Run chart-testing (lint)
+        run: |
+          ct lint --debug --charts . --chart-dirs "$(pwd)"
+
+      - name: Create kind cluster
+        uses: helm/kind-action@94729529f85113b88f4f819c17ce61382e6d8478 # v1.2.0
+
+      - name: Write Testing Api Key Secrets to values file
+        env:
+          API_KEY_US: "tbd" # reference secret
+          API_KEY_EU: "tbd"
+        run: |
+          mkdir -p ci/
+          echo -e 'scalyr:\n  apiKey: "${API_KEY_US}"' > ci/test-values.yaml
+
+      # TODO: Configure testing write API key as Github repo secret
+      # TODO: Ideally we would also use read api key to confirm agent.log is correctly ingested
+      # TODO: Run install twice (against US and EU)
+      - name: Run chart-testing (install) - daemonset controller type
+        env:
+          API_KEY: "tbd" # reference secret
+        run: |
+          # Write test values to a file which is used by ct install
+          mkdir -p ci/
+          echo -e 'controllerType: "daemonset"\nscalyr:\n  apiKey: "${API_KEY}"' > ci/test-values.yaml
+
+          ct install --debug --charts . --chart-dirs "$(pwd)"
+
+      - name: Run chart-testing (install) - deployment controller type
+        env:
+          API_KEY: "tbd" # reference secret
+        run: |
+          # Write test values to a file which is used by ct install
+          mkdir -p ci/
+          echo -e 'controllerType: "deployment"\nscalyr:\n  apiKey: "${API_KEY}"' > ci/test-values.yaml
+
+          ct install --debug --charts . --chart-dirs "$(pwd)"

--- a/.github/workflows/lint_tests.yml
+++ b/.github/workflows/lint_tests.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - permissions_change_gha_workflow
   pull_request:
     branches:
       - master

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.venv/
+venv/
+ci/test-values.yaml

--- a/.helmignore
+++ b/.helmignore
@@ -21,3 +21,6 @@
 .idea/
 *.tmproj
 .vscode/
+# Python venv
+.venv/
+venv/

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -13,3 +13,7 @@ home: https://github.com/dodevops/helm-scalyr
 icon: https://app.scalyr.com/s2/src/img/logo-reverse.png
 sources:
   - https://github.com/dodevops/helm-scalyr
+maintainers:
+  - name: dploeger
+    email: develop@dieploegers.de
+    url: https://github.com/dploeger

--- a/README.md
+++ b/README.md
@@ -146,4 +146,5 @@ act
 ```
 
 Keep in mind that it may take a while since it needs to pull down a large Docker image during the
-first run.
+first run. This tool also may not work correctly on some operating systems since it relies on
+Docker inside Docker functionality for creating kind Kubernetes cluster.

--- a/README.md
+++ b/README.md
@@ -89,3 +89,61 @@ If you'd like to create a different Scalyr agent, you can set `controllerType` t
 | volumeMounts | object | `{}` | Additional volume mounts to set up |
 | volumes | object | `{}` | Additional volumes to mount |
 
+## Development, CI/CD
+
+On each push to master and other branches Github Actions workflow runs which performs basic helm
+lint and helm install sanity checks against the changes.
+
+[chart-testing](https://github.com/helm/chart-testing) wrapper is used for running helm lint and
+helm install.
+
+To run those checks locally, you need the following tools installed:
+
+* helm 3
+* chart-testing
+* minikube (or kind cluster against which helm install can run)
+* Python 3 with the following 3 libraries installed - yamllint, yamale 
+
+```bash
+# 1. Install helm
+curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+# 2. Install minikube
+curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+sudo install minikube-linux-amd64 /usr/local/bin/minikube
+
+# 3. Install chart-testing
+wget https://github.com/helm/chart-testing/releases/download/v3.4.0/chart-testing_3.4.0_linux_amd64.tar.gz
+tar -xzvf chart-testing_3.4.0_linux_amd64.tar.gz
+sudo mv ct /usr/local/bin
+sudo mv etc ~/.ct
+
+# 4. Create Python virtualenv and install libraries needed by chart testing
+python3 -m venv .venv
+source .venv/bin/activate
+pip install yamale yamllint
+
+# 5. Start minikube Kubernetes cluster
+minikube start
+
+# 6. Run actual lint and install task
+ct lint --debug --charts . --chart-dirs "$(pwd)"
+
+# To use valid API key
+mkdir -p ci/
+echo -e 'scalyr:\n  apiKey: "SCALYR_TEST_WRITE_API_KEY"' > ci/test-values.yaml
+
+ct install --debug --charts . --chart-dirs "$(pwd)"
+```
+
+As an alternative to manually installing those tools and setting up the environment, you can also
+use [act](https://github.com/nektos/act) tool which allows you to run GHA workflow locally inside
+Docker containers as shown below.
+
+```bash
+act lint_test
+act
+```
+
+Keep in mind that it may take a while since it needs to pull down a large Docker image during the
+first run.

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -46,6 +46,7 @@ spec:
         - name: "scalyr-config-agent-d"
           configMap:
             name: "{{ include "scalyr-helm.fullname" . }}-config-agent-d"
+            defaultMode: 0600
       {{- if .Values.volumes }}
       {{ toYaml .Values.volumes | nindent 8 }}
       {{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -47,6 +47,7 @@ spec:
         - name: "scalyr-config-agent-d"
           configMap:
             name: "{{ include "scalyr-helm.fullname" . }}-config-agent-d"
+            defaultMode: 0600
       {{- if .Values.volumes }}
       {{ toYaml .Values.volumes | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
This PR includes two changes:

1. Set 0600 permission mask for kubernetes.json file which is written as part of a ConfigMap

This means agent won't log "permissions for file are too open" warning on startup.

Right now this file doesn't actually contain any secrets and file being readable to group / others is usually not a big deal in container environments, but doing that we avoid that warning being emitted on start up and each time config is parsed.

2. Add Github actions workflow which runs helm lint and install checks

This workflow runs helm lint against the chart and also verifies that the chart can be successfully installed against "kind" Kubernetes cluster. It utilizes chart testing tool (https://github.com/helm/chart-testing) + helm.

Here is how the build output looks like - https://github.com/Kami/helm-scalyr/actions/runs/1311439805.

Right now we don't use a valid API key, but long term we should figure out how to approach that and also add another step at the end which verifies not just that the chart has been successfully installed, but also that agent.log has been successfully ingested (and some other scenarios as well - ingesting k8s cluster metrics and ingesting log file from another pod inside the cluster, but that will be a bit more involved).

Another possible build optimization / speed up (since creating a kind cluster for install task can take 70+ seconds) would be to only run helm lint and install against changed files, but that would require quite a bit more complex Github Actions Workflow file and we would still want to run lint + install check against all the files on merge / push to master at the very least.